### PR TITLE
Fix metadata aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.3.1 (2023-09-20)
+
+- Fixed Font Awesome aliases for `credit-card-line` and `credit-card-solid`. [#60](https://github.com/blackbaud/skyux-icons/pull/60)
+
 # 6.3.0 (2023-09-19)
 
 - Added a `VERSION` object to the public exports API. [#59](https://github.com/blackbaud/skyux-icons/pull/59)

--- a/metadata.json
+++ b/metadata.json
@@ -271,12 +271,12 @@
     {
       "name": "credit-card-line",
       "usage": ["Credit card"],
-      "faName": "credit-card-o"
+      "faName": "credit-card"
     },
     {
       "name": "credit-card-solid",
       "usage": ["Credit card"],
-      "faName": "credit-card"
+      "faName": "credit-card-alt"
     },
     {
       "name": "money-line",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyux/icons",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyux/icons",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/icons",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "main": "./index.js",
   "types": "./index.d.ts",
   "description": "A glyph font and stylesheet for displaying SKY UX icons.",


### PR DESCRIPTION
FA uses [`credit-card`](https://fontawesome.com/v4/icon/credit-card) and [`credit-card-alt`](https://fontawesome.com/v4/icon/credit-card-alt).