### PR TITLE
ci: use token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,3 +32,4 @@ jobs:
           prerelease: ${{ env.PRERELEASE == 'true' }}
           draft-pull-request: true
           include-v-in-tag: false
+          token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'


### PR DESCRIPTION
PR Actions will not run for a PR opened by the generated token. Switching to use a secret token.