### PR TITLE
fix: copy-to-clipboard uses correct Font Awesome fallback

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
     {
       "name": "copy-to-clipboard-line",
       "usage": ["Copy to clipboard"],
-      "faNames": ["folder-open-o"]
+      "faNames": ["clipboard"]
     },
     {
       "name": "copy-line",


### PR DESCRIPTION
AB#2857742