### PR TITLE
feat: add panel icons for omnibar

### DIFF
--- a/src/svg/fluent-icon-list.txt
+++ b/src/svg/fluent-icon-list.txt
@@ -169,6 +169,8 @@ open
 options
 organization-horizontal
 paint-brush
+panel-left-contract
+panel-left-expand
 pause-circle
 payment
 payment-wireless


### PR DESCRIPTION
Adding 'panel-left-contract' for collapse and 'panel-left-expand' for expand in vertical omnibar