### PR TITLE
chore: release 10.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [10.7.0](https://github.com/blackbaud/skyux-icons/compare/10.6.0...10.7.0) (2026-02-24)
+
+
+### Features
+
+* add table multiple and column single ([#251](https://github.com/blackbaud/skyux-icons/issues/251)) ([1b13d35](https://github.com/blackbaud/skyux-icons/commit/1b13d35f5160de1a25f00dba37e9a3896b4dc924))
+
 # [10.6.0](https://github.com/blackbaud/skyux-icons/compare/10.5.0...10.6.0) (2026-02-11)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyux/icons",
-  "version": "10.6.0",
+  "version": "10.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyux/icons",
-      "version": "10.6.0",
+      "version": "10.7.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/compat": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/icons",
-  "version": "10.6.0",
+  "version": "10.7.0",
   "main": "./index.js",
   "types": "./index.d.ts",
   "description": "A sprite map for SKY UX SVG icons.",


### PR DESCRIPTION
## [10.7.0](https://github.com/blackbaud/skyux-icons/compare/10.6.0...10.7.0) (2026-02-24)


### Features

* add table multiple and column single ([#251](https://github.com/blackbaud/skyux-icons/issues/251)) ([1b13d35](https://github.com/blackbaud/skyux-icons/commit/1b13d35f5160de1a25f00dba37e9a3896b4dc924))