### PR TITLE
chore: release 11.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [11.2.0](https://github.com/blackbaud/skyux-icons/compare/11.1.0...11.2.0) (2026-07-13)
+
+
+### Features
+
+* update fluent icons ([#266](https://github.com/blackbaud/skyux-icons/issues/266)) ([87a199e](https://github.com/blackbaud/skyux-icons/commit/87a199e6205ea092322a2648e137379be1761db7))
+
 ## [11.1.0](https://github.com/blackbaud/skyux-icons/compare/11.0.0...11.1.0) (2026-05-01)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyux/icons",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyux/icons",
-      "version": "11.1.0",
+      "version": "11.2.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/compat": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/icons",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "main": "./index.js",
   "types": "./index.d.ts",
   "description": "A sprite map for SKY UX SVG icons.",


### PR DESCRIPTION
## [11.2.0](https://github.com/blackbaud/skyux-icons/compare/11.1.0...11.2.0) (2026-07-13)


### Features

* update fluent icons ([#266](https://github.com/blackbaud/skyux-icons/issues/266)) ([87a199e](https://github.com/blackbaud/skyux-icons/commit/87a199e6205ea092322a2648e137379be1761db7))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Fluent icon set for a refreshed and more consistent visual experience.

- **Documentation**
  - Added release notes for version 11.2.0, documenting the icon updates and release details.

- **Chores**
  - Released version 11.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->