### PR TITLE
chore: changelog for 10.8.0 (#271) 🍒

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [10.8.0](https://github.com/blackbaud/skyux-icons/compare/10.7.0...10.8.0) (2026-08-11)
+
+
+### Features
+
+* add megaphone-loud ([#270](https://github.com/blackbaud/skyux-icons/issues/270)) ([6a8e550](https://github.com/blackbaud/skyux-icons/commit/6a8e550aae96ada9a7de4541281274f442d33dc0)), closes [AB#4083623](https://dev.azure.com/blackbaud/Products/_workitems/edit/4083623)
+
 ## [11.2.0](https://github.com/blackbaud/skyux-icons/compare/11.1.0...11.2.0) (2026-07-13)
 
 


### PR DESCRIPTION
:cherries: Cherry picked from #271 [chore: release 10.8.0](https://github.com/blackbaud/skyux-icons/pull/271)

AB#4083623 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for version 10.8.0.
  * Documented the addition of the `megaphone-loud` icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->