### PR TITLE
chore: release 11.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
 
+## [11.3.0](https://github.com/blackbaud/skyux-icons/compare/11.2.0...11.3.0) (2026-08-11)
+
+
+### Features
+
+* add megaphone-loud ([#270](https://github.com/blackbaud/skyux-icons/issues/270)) ([#273](https://github.com/blackbaud/skyux-icons/issues/273)) ([507b54d](https://github.com/blackbaud/skyux-icons/commit/507b54d13ae7e3585adef8fd47115563787af8d1)), closes [AB#4083623](https://dev.azure.com/blackbaud/Products/_workitems/edit/4083623)
+
+## [10.8.0](https://github.com/blackbaud/skyux-icons/compare/10.7.0...11.2.0) (2026-08-11)
+
+
+### Features
+
+* add megaphone-loud ([#270](https://github.com/blackbaud/skyux-icons/issues/270)) ([6a8e550](https://github.com/blackbaud/skyux-icons/commit/6a8e550aae96ada9a7de4541281274f442d33dc0)), closes [AB#4083623](https://dev.azure.com/blackbaud/Products/_workitems/edit/4083623)
+
 ## [10.8.0](https://github.com/blackbaud/skyux-icons/compare/10.7.0...10.8.0) (2026-08-11)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyux/icons",
-  "version": "11.2.0",
+  "version": "11.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyux/icons",
-      "version": "11.2.0",
+      "version": "11.3.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/compat": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/icons",
-  "version": "11.2.0",
+  "version": "11.3.0",
   "main": "./index.js",
   "types": "./index.d.ts",
   "description": "A sprite map for SKY UX SVG icons.",


### PR DESCRIPTION
## [11.3.0](https://github.com/blackbaud/skyux-icons/compare/11.2.0...11.3.0) (2026-08-11)


### Features

* add megaphone-loud ([#270](https://github.com/blackbaud/skyux-icons/issues/270)) ([#273](https://github.com/blackbaud/skyux-icons/issues/273)) ([507b54d](https://github.com/blackbaud/skyux-icons/commit/507b54d13ae7e3585adef8fd47115563787af8d1)), closes [AB#4083623](https://dev.azure.com/blackbaud/Products/_workitems/edit/4083623)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `megaphone-loud` icon to the icon library.

- **Documentation**
  - Updated the changelog with release information for versions 11.3.0 and 10.8.0.

- **Chores**
  - Updated the package version to 11.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->